### PR TITLE
Export the Twitter symbol explicitly for use in Meteor 0.6.5 and above

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,6 +6,7 @@ Package.on_use(function (api, where) {
   api.use([
     'accounts-twitter'
   ], 'server');
+  api.export && api.export('Twitter', 'server');
 
   api.add_files(['lib/twitter.js'], 'server');
 });


### PR DESCRIPTION
Meteor 0.6.5 requires pacakge exports to be declared. Added in a way that should be backwards compatable with pre-0.6.5 too.

"Since Geoff's big email, we simplified the way that exports from 
packages work.  There's no more magic comment scanner: you just 
declare exports in the on_use function with 

   api.export('MySymbol', 'server'); 
" — https://groups.google.com/forum/#!topic/meteor-talk/YOStFiuzbO8
